### PR TITLE
Fix malformed package.json

### DIFF
--- a/functions/lib/package.json
+++ b/functions/lib/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "notes-functions-lib",
-  "version": "0.1.0",
+  "name": "notes-functions-lib",
+  "version": "0.1.0",
   "dependencies": {
-    "uuid": "^2.0.1"
+      "uuid": "^2.0.1"
   }
 }


### PR DESCRIPTION
The json fix contains hidden characters causing `npm i` to fail

![image](https://cloud.githubusercontent.com/assets/532272/16058209/30fe4224-3232-11e6-9c9c-9ca5182cd855.png)

This might be happening in other places from your IDE. 

Just a heads up! =)
